### PR TITLE
Fix artist page loading and sync system

### DIFF
--- a/supabase/functions/sync-shows/index.ts
+++ b/supabase/functions/sync-shows/index.ts
@@ -208,7 +208,7 @@ serve(async (req) => {
         min_price: minPrice,
         max_price: maxPrice,
         currency: priceRange?.currency || "USD",
-        ticketmaster_id: event.id,
+        tm_event_id: event.id,
         status:
           new Date(event.dates.start.localDate) > new Date()
             ? "upcoming"


### PR DESCRIPTION
## Description

This pull request addresses a critical issue preventing shows from loading correctly on artist pages. The `supabase/functions/sync-shows` Edge Function was attempting to upsert Ticketmaster event IDs into an incorrect database column (`ticketmaster_id`). This change updates the function to use the correct `tm_event_id` column, ensuring that show data is properly stored and displayed.

## Related Issues

Closes #<issue_number>

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

This is the initial step to resolve the broader issue of shows not appearing on artist pages and the incomplete sync/cron job system. Further changes will follow to align other parts of the codebase (e.g., Drizzle schema, API routes) with the correct `tm_event_id` usage and ensure the full sync process functions as expected.

---
<a href="https://cursor.com/background-agent?bcId=bc-71264f67-850d-470e-9b7e-1ca7fcbb8f40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-71264f67-850d-470e-9b7e-1ca7fcbb8f40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

